### PR TITLE
Add detect-secrets GitHub action

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,138 @@
+{
+  "version": "1.5.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "GitLabTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "IPPublicDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "OpenAIDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "PypiTokenDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TelegramBotTokenDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    },
+    {
+      "path": "detect_secrets.filters.regex.should_exclude_file",
+      "pattern": [
+        ".secrets.*",
+        ".git*"
+      ]
+    }
+  ],
+  "results": {},
+  "generated_at": "2025-01-14T09:35:49Z"
+}

--- a/detect-secrets/README.md
+++ b/detect-secrets/README.md
@@ -21,10 +21,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Run detect-secrets action
-      uses: ./detect-secrets
+      uses: deamen/gh-actions/detect-secrets@master # or sha of the commitzs
       with:
         baseline-file: '.secrets.baseline'
 ```
@@ -36,4 +36,4 @@ None
 ## Error Handling
 
 - If the .baseline file does not exist, the action exits with code 1 and outputs an error message.
-- If secrets are detected, the action exits with code 1 and outputs the detect-secrets message.
+- If secrets are detected, the action exits with code 1 and outputs the sorted detect-secrets message in format `> filename,hashed_secret,line_number`.

--- a/detect-secrets/README.md
+++ b/detect-secrets/README.md
@@ -1,0 +1,39 @@
+# Detect Secrets Action
+
+This action runs yelp/detect-secrets to scan for secrets in the repository.
+
+## Inputs
+
+### `baseline-file`
+
+**Required** The path to the .baseline file.
+
+## Example usage
+
+```yaml
+name: Detect Secrets
+
+on: [push, pull_request]
+
+jobs:
+  detect-secrets:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Run detect-secrets action
+      uses: ./detect-secrets
+      with:
+        baseline-file: '.secrets.baseline'
+```
+
+## Outputs
+
+None
+
+## Error Handling
+
+- If the .baseline file does not exist, the action exits with code 1 and outputs an error message.
+- If secrets are detected, the action exits with code 1 and outputs the detect-secrets message.

--- a/detect-secrets/action.yml
+++ b/detect-secrets/action.yml
@@ -12,6 +12,7 @@ runs:
       with:
         python-version: '3.12'
     - name: Install detect-secrets
+      shell: bash
       run: |
         python -m pip install detect-secrets
     - name: Run detect-secrets scan

--- a/detect-secrets/action.yml
+++ b/detect-secrets/action.yml
@@ -1,0 +1,19 @@
+name: 'Detect Secrets'
+description: 'A GitHub Action to run yelp/detect-secrets to scan for secrets in the repository'
+inputs:
+  baseline-file:
+    description: 'The path to the .baseline file'
+    required: true
+runs:
+  using: 'composite'
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.12'
+    - name: Install detect-secrets
+      run: |
+        python -m pip install detect-secrets
+    - name: Run detect-secrets scan
+      shell: bash
+      run: ${GITHUB_ACTION_PATH}/scan_secrets.sh ${{ inputs.baseline-file }}

--- a/detect-secrets/scan_secrets.sh
+++ b/detect-secrets/scan_secrets.sh
@@ -1,21 +1,50 @@
 #!/bin/bash
 
-# Check for the existence of the .baseline file
-BASELINE_FILE=$1
-if [ ! -f "$BASELINE_FILE" ]; then
-  echo "Error: .baseline file not found. Please create a baseline file first."
+# Script to check for secrets using detect-secrets
+
+# Check if baseline file is provided
+if [ $# -lt 1 ]; then
+  echo "Usage: $0 <baseline_file>"
   exit 1
 fi
 
-# Run detect-secrets scan with the .baseline file
-SCAN_OUTPUT=$(detect-secrets scan --baseline "$BASELINE_FILE")
-SCAN_EXIT_CODE=$?
+BASELINE_FILE=$1
 
-# Handle errors and exit codes as specified
-if [ $SCAN_EXIT_CODE -ne 0 ]; then
-  echo "Error: Secrets detected by detect-secrets."
+# Check if the baseline file exists
+if [ ! -f "$BASELINE_FILE" ]; then
+  echo "Error: Baseline file '$BASELINE_FILE' not found. Please create one first."
+  exit 1
+fi
+
+TMP_BASELINE_FILE=".secrets.tmp"
+
+# Backup the baseline file to a temporary file
+cp "$BASELINE_FILE" "$TMP_BASELINE_FILE"
+
+# Perform the detect-secrets scan
+detect-secrets scan --baseline "$TMP_BASELINE_FILE" --exclude-files '.secrets.*' --exclude-files '.git*'
+
+# Function to compare secrets between baseline and temporary file
+compare_secrets() {
+  diff <(
+    jq -r '.results | keys[] as $key | "\($key),\(.[$key] | .[] | .hashed_secret),\(.[$key] | .[] | .line_number)"' "$1" | sort
+  ) <(
+    jq -r '.results | keys[] as $key | "\($key),\(.[$key] | .[] | .hashed_secret),\(.[$key] | .[] | .line_number)"' "$2" | sort
+  ) | grep '^>'
+}
+
+# Capture output of the comparison
+SCAN_OUTPUT=$(compare_secrets "$BASELINE_FILE" "$TMP_BASELINE_FILE")
+# Clean up temporary files
+rm "$TMP_BASELINE_FILE"
+
+# Check the results of the scan and handle errors
+if [ -n "$SCAN_OUTPUT" ]; then
+  echo "Error: Secrets detected:"
   echo "$SCAN_OUTPUT"
   exit 1
+else
+  echo "No secrets detected."
+  exit 0
 fi
 
-echo "No secrets detected."

--- a/detect-secrets/scan_secrets.sh
+++ b/detect-secrets/scan_secrets.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Check for the existence of the .baseline file
+BASELINE_FILE=$1
+if [ ! -f "$BASELINE_FILE" ]; then
+  echo "Error: .baseline file not found. Please create a baseline file first."
+  exit 1
+fi
+
+# Run detect-secrets scan with the .baseline file
+SCAN_OUTPUT=$(detect-secrets scan --baseline "$BASELINE_FILE")
+SCAN_EXIT_CODE=$?
+
+# Handle errors and exit codes as specified
+if [ $SCAN_EXIT_CODE -ne 0 ]; then
+  echo "Error: Secrets detected by detect-secrets."
+  echo "$SCAN_OUTPUT"
+  exit 1
+fi
+
+echo "No secrets detected."


### PR DESCRIPTION
Fixes #6

Add a new GitHub action to run yelp/detect-secrets for scanning secrets in the repository.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/deamen/gh-actions/pull/7?shareId=167650b9-f941-4737-a00c-5c05abcf8710).