### PR TITLE
Do not fail check_binary_files action if no file is detected in commit

### DIFF
--- a/check-binary-files/check_binary_files.sh
+++ b/check-binary-files/check_binary_files.sh
@@ -63,7 +63,7 @@ for commit in $commits; do
     done
   else
     echo "No files detected in commit $commit"
-    exit 1
+    continue
   fi
 done
 
@@ -76,4 +76,3 @@ if [ -n "$binary_files" ]; then
 else
   echo "No binary files detected."
 fi
-


### PR DESCRIPTION
Fixes #8

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/deamen/gh-actions/pull/9?shareId=e9d21e13-c841-44c8-b18c-142be80b678e).